### PR TITLE
Fix typo: acronym is 頭字語

### DIFF
--- a/README-jaJP.md
+++ b/README-jaJP.md
@@ -477,7 +477,7 @@
   ```
 
 * <a name="camel-case"></a>
-  モジュール名は`CamelCase`を使うこと(HTTP, RFC, XMLなどの頭地語はそのままでよい)
+  モジュール名は`CamelCase`を使うこと(HTTP, RFC, XMLなどの頭字語はそのままでよい)
   <sup>[[link](#camel-case)]</sup>
 
   ```elixir


### PR DESCRIPTION
[頭字語 - Wikipedia](https://ja.wikipedia.org/wiki/%E9%A0%AD%E5%AD%97%E8%AA%9E)