### PR TITLE
Fix the title of 'Syntax'

### DIFF
--- a/README-jaJP.md
+++ b/README-jaJP.md
@@ -249,7 +249,7 @@
   <sup>[[link](#newline-eof)]</sup>
 
 
-### シンタックス
+### 構文
 
 * <a name="parentheses"></a>
    `def` が引数をとる場合は括弧を使うこと。引数がない場合は省略すること。


### PR DESCRIPTION
In the table of contents, 'Syntax' is translated into ’構文'.
At the title of section, it is translated into 'シンタックス'.
This makes the link broken.